### PR TITLE
Resolves #86: Separate Game Selection into its own view

### DIFF
--- a/src/Game/Game.elm
+++ b/src/Game/Game.elm
@@ -457,7 +457,7 @@ modeSelectorElements model =
                 , Border.rounded Styles.pillBorderRadius
                 , Element.paddingXY 10 6
                 ]
-                [ Element.el [ Font.bold, Element.centerY ] <|
+                [ Element.el [ Font.bold, Element.centerY, Element.width (Element.px 115) ] <|
                     Element.text <|
                         case model.game.gameInteractionMode of
                             Reveal ->

--- a/src/Game/Game.elm
+++ b/src/Game/Game.elm
@@ -44,9 +44,9 @@ import Time
 import Types exposing (..)
 
 
-initModel : GameModel
-initModel =
-    { gameBoardStatus = NoGame PreSelect
+initModel : PlayGroundDefinition -> GameModel
+initModel definition =
+    { gameBoardStatus = WaitOnStart <| createInitGameGrid definition
     , gameInteractionMode = Reveal
     , gameRunningTimes = []
     , gamePauseResumeState = Paused
@@ -64,9 +64,9 @@ decodeStoredFinishedGameHistory string =
         |> Result.withDefault []
 
 
-subscriptions : Model -> Sub GameMsg
-subscriptions m =
-    case ( m.currentView, m.game.gameBoardStatus ) of
+subscriptions : Model -> GameModel -> Sub GameMsg
+subscriptions m gameModel =
+    case ( m.currentView, gameModel.gameBoardStatus ) of
         ( Game, RunningGame _ ) ->
             Sub.batch
                 [ Time.every 200 (\posix -> ClockTick posix)
@@ -106,44 +106,29 @@ toKeyEventMsg eventKeyString =
 ----- UPDATE -----
 
 
-update : GameMsg -> Model -> ( Model, Cmd GameMsg )
-update gameMsg model =
+update : GameMsg -> GameModel -> Model -> ( Model, Cmd GameMsg )
+update gameMsg gameModel model =
     case gameMsg of
         NoUpdate ->
             ( model, Cmd.none )
 
         GoToStartPage ->
-            let
-                gameModel =
-                    model.game
-            in
-            ( { model | game = { gameModel | gameBoardStatus = NoGame PreSelect } }, Cmd.none )
+            ( model, Cmd.none )
 
         ClickedOnInitGameCell initGame coords ->
             ( model, generatePlayGameGrid initGame coords |> Random.generate StartGame )
 
         StartGame playGrid ->
-            let
-                gameModel =
-                    model.game
-            in
-            ( { model | game = { gameModel | gameBoardStatus = RunningGame playGrid, gameRunningTimes = [], gamePauseResumeState = Resumed 1 } }, Cmd.none )
+            ( { model | game = Just { gameModel | gameBoardStatus = RunningGame playGrid, gameRunningTimes = [], gamePauseResumeState = Resumed 1 } }, Cmd.none )
 
-        CreateNewGame playgroundDefinition ->
-            let
-                gameModel =
-                    model.game
-            in
-            ( { model | game = { gameModel | gameBoardStatus = WaitOnStart <| createInitGameGrid playgroundDefinition, gameInteractionMode = Reveal } }, Cmd.none )
+        CreateNewGame _ ->
+            ( model, Cmd.none )
 
         ClickOnGameCell coords ->
-            updateModelByClickOnGameCell coords model
+            updateModelByClickOnGameCell coords gameModel model
 
         ToogleGameCellInteractionMode ->
             let
-                gameModel =
-                    model.game
-
                 nextMode =
                     case gameModel.gameInteractionMode of
                         Reveal ->
@@ -152,13 +137,13 @@ update gameMsg model =
                         Flag ->
                             Reveal
             in
-            ( { model | game = { gameModel | gameInteractionMode = nextMode } }, Cmd.none )
+            ( { model | game = Just { gameModel | gameInteractionMode = nextMode } }, Cmd.none )
 
         ToogleGamePause ->
-            ( togglePause model, Cmd.none )
+            ( togglePause gameModel model, Cmd.none )
 
         ClockTick posix ->
-            updateTimePlayGame model posix
+            updateTimePlayGame gameModel model posix
 
         NavigationEvent to ->
             case ( model.currentView, to ) of
@@ -166,40 +151,33 @@ update gameMsg model =
                     ( model, Cmd.none )
 
                 ( Game, _ ) ->
-                    ( togglePause model, Cmd.none )
+                    ( togglePause gameModel model, Cmd.none )
 
                 ( _, Game ) ->
-                    ( togglePause model, Cmd.none )
+                    ( togglePause gameModel model, Cmd.none )
 
                 ( _, _ ) ->
                     ( model, Cmd.none )
 
 
-togglePause : Model -> Model
-togglePause model =
-    let
-        gameModel =
-            model.game
-    in
+togglePause : GameModel -> Model -> Model
+togglePause gameModel model =
     case ( gameModel.gameBoardStatus, gameModel.gamePauseResumeState ) of
         ( RunningGame _, Paused ) ->
-            { model | game = { gameModel | gamePauseResumeState = Resumed (List.length gameModel.gameRunningTimes + 1) } }
+            { model | game = Just { gameModel | gamePauseResumeState = Resumed (List.length gameModel.gameRunningTimes + 1) } }
 
         ( RunningGame _, Resumed _ ) ->
-            { model | game = { gameModel | gamePauseResumeState = Paused } }
+            { model | game = Just { gameModel | gamePauseResumeState = Paused } }
 
         _ ->
             model
 
 
-updateTimePlayGame : Model -> Time.Posix -> ( Model, Cmd GameMsg )
-updateTimePlayGame model time =
-    case ( model.game.gameBoardStatus, model.game.gamePauseResumeState ) of
+updateTimePlayGame : GameModel -> Model -> Time.Posix -> ( Model, Cmd GameMsg )
+updateTimePlayGame gameModel model time =
+    case ( gameModel.gameBoardStatus, gameModel.gamePauseResumeState ) of
         ( RunningGame _, Resumed timesResume ) ->
             let
-                gameModel =
-                    model.game
-
                 shouldReplaceHead =
                     List.length gameModel.gameRunningTimes == timesResume
 
@@ -213,22 +191,19 @@ updateTimePlayGame model time =
                                 ( start, time ) :: xs
 
                     else
-                        ( time, time ) :: model.game.gameRunningTimes
+                        ( time, time ) :: gameModel.gameRunningTimes
             in
-            ( { model | game = { gameModel | gameRunningTimes = newList, lastClockTick = time } }, Cmd.none )
+            ( { model | game = Just { gameModel | gameRunningTimes = newList, lastClockTick = time } }, Cmd.none )
 
         _ ->
             ( model, Cmd.none )
 
 
-updateModelByClickOnGameCell : Coordinate -> Model -> ( Model, Cmd GameMsg )
-updateModelByClickOnGameCell coords model =
-    case ( model.game.gamePauseResumeState, model.game.gameBoardStatus ) of
+updateModelByClickOnGameCell : Coordinate -> GameModel -> Model -> ( Model, Cmd GameMsg )
+updateModelByClickOnGameCell coords gameModel model =
+    case ( gameModel.gamePauseResumeState, gameModel.gameBoardStatus ) of
         ( Resumed _, RunningGame playGrid ) ->
             let
-                gameModel =
-                    model.game
-
                 updatedPlayGrid : PlayGameGrid
                 updatedPlayGrid =
                     case gameModel.gameInteractionMode of
@@ -267,7 +242,7 @@ updateModelByClickOnGameCell coords model =
                         _ ->
                             model.playedGameHistory
             in
-            ( { model | game = { gameModel | gameBoardStatus = nextGameBoardStatus }, playedGameHistory = nextHistoryList }, saveFinishedGameHistory nextHistoryList )
+            ( { model | game = Just { gameModel | gameBoardStatus = nextGameBoardStatus }, playedGameHistory = nextHistoryList }, saveFinishedGameHistory nextHistoryList )
 
         _ ->
             ( model, Cmd.none )
@@ -277,8 +252,8 @@ updateModelByClickOnGameCell coords model =
 ----- VIEW for Game -----
 
 
-view : Model -> Element GameMsg
-view model =
+view : Model -> GameModel -> Element GameMsg
+view model gameModel =
     let
         boardConfigFromDefinition : PlayGroundDefinition -> BoardViewConfig
         boardConfigFromDefinition definition =
@@ -353,8 +328,8 @@ boardViewConfig model cols rows =
     }
 
 
-gameScreenLayout : Model -> BoardViewConfig -> Element GameMsg -> Element GameMsg
-gameScreenLayout model boardConfig boardElement =
+gameScreenLayout : Model -> GameModel -> BoardViewConfig -> Element GameMsg -> Element GameMsg
+gameScreenLayout model gameModel boardConfig boardElement =
     if boardConfig.isMobile then
         Element.column
             [ Element.width Element.fill
@@ -428,9 +403,9 @@ desktopPauseButtonFontSize =
     42
 
 
-gameInformationElements : Model -> List (Element GameMsg)
-gameInformationElements model =
-    case getRunningGameStats model.game of
+gameInformationElements : Model -> GameModel -> List (Element GameMsg)
+gameInformationElements model gameModel =
+    case getRunningGameStats gameModel of
         Nothing ->
             []
 
@@ -441,9 +416,9 @@ gameInformationElements model =
             ]
 
 
-modeSelectorElements : Model -> List (Element GameMsg)
-modeSelectorElements model =
-    case model.game.gameBoardStatus of
+modeSelectorElements : Model -> GameModel -> List (Element GameMsg)
+modeSelectorElements model gameModel =
+    case gameModel.gameBoardStatus of
         RunningGame _ ->
             [ Element.row
                 [ Element.spacing 8
@@ -467,9 +442,9 @@ modeSelectorElements model =
             []
 
 
-giveUpElements : Model -> List (Element GameMsg)
-giveUpElements model =
-    case model.game.gameBoardStatus of
+giveUpElements : Model -> GameModel -> List (Element GameMsg)
+giveUpElements model gameModel =
+    case gameModel.gameBoardStatus of
         FinishedGame _ _ _ ->
             []
 
@@ -487,12 +462,9 @@ giveUpElements model =
                 }
             ]
 
-        _ ->
-            []
 
-
-pauseToggleElements : Model -> List (Element GameMsg)
-pauseToggleElements model =
+pauseToggleElements : Model -> GameModel -> List (Element GameMsg)
+pauseToggleElements model gameModel =
     let
         buttonAttributes =
             [ Border.solid
@@ -525,14 +497,14 @@ pauseToggleElements model =
             []
 
 
-gameActionElements : Model -> List (Element GameMsg)
-gameActionElements model =
-    modeSelectorElements model ++ giveUpElements model ++ pauseToggleElements model
+gameActionElements : Model -> GameModel -> List (Element GameMsg)
+gameActionElements model gameModel =
+    modeSelectorElements model gameModel ++ giveUpElements model gameModel ++ pauseToggleElements model gameModel
 
 
-gameFinishedElements : Model -> List (Element GameMsg)
-gameFinishedElements model =
-    case model.game.gameBoardStatus of
+gameFinishedElements : Model -> GameModel -> List (Element GameMsg)
+gameFinishedElements model gameModel =
+    case gameModel.gameBoardStatus of
         FinishedGame playGameGrid gameResult _ ->
             [ Styles.pillBadge model.theme <|
                 case gameResult of
@@ -555,16 +527,16 @@ gameFinishedElements model =
             []
 
 
-mobileStatusBarElement : Model -> Element GameMsg
-mobileStatusBarElement model =
-    wrapIfNotEmpty (gameInformationElements model)
+mobileStatusBarElement : Model -> GameModel -> Element GameMsg
+mobileStatusBarElement model gameModel =
+    wrapIfNotEmpty (gameInformationElements model gameModel)
 
 
-mobileActionBarElement : Model -> Element GameMsg
-mobileActionBarElement model =
+mobileActionBarElement : Model -> GameModel -> Element GameMsg
+mobileActionBarElement model gameModel =
     let
         actionElements =
-            gameActionElements model ++ gameFinishedElements model
+            gameActionElements model gameModel ++ gameFinishedElements model gameModel
     in
     wrapIfNotEmpty actionElements
 
@@ -583,16 +555,16 @@ wrapIfNotEmpty elements =
             elements
 
 
-sidebarElement : Model -> Element GameMsg
-sidebarElement model =
+sidebarElement : Model -> GameModel -> Element GameMsg
+sidebarElement model gameModel =
     Element.column
         [ Element.width Element.shrink
         , Element.alignTop
         , Element.spacing 12
         ]
-        (gameInformationElements model
-            ++ gameActionElements model
-            ++ gameFinishedElements model
+        (gameInformationElements model gameModel
+            ++ gameActionElements model gameModel
+            ++ gameFinishedElements model gameModel
             ++ [ Element.column [ Font.bold ]
                     [ Element.text "Shortcuts:"
                     , Element.text "T: Toggle Selector"

--- a/src/Game/Game.elm
+++ b/src/Game/Game.elm
@@ -457,7 +457,7 @@ modeSelectorElements model =
                 , Border.rounded Styles.pillBorderRadius
                 , Element.paddingXY 10 6
                 ]
-                [ Element.el [ Font.bold, Element.centerY, Element.width (Element.px 115) ] <|
+                [ Element.el [ Font.bold, Element.centerY, Element.width (Element.px 130) ] <|
                     Element.text <|
                         case model.game.gameInteractionMode of
                             Reveal ->

--- a/src/Game/Game.elm
+++ b/src/Game/Game.elm
@@ -1013,9 +1013,6 @@ getRunningGameStats gameModel =
                 , elapsedTime = 0
                 }
 
-        _ ->
-            Nothing
-
 
 type alias GameStats =
     { mines : Int

--- a/src/Game/Game.elm
+++ b/src/Game/Game.elm
@@ -307,7 +307,13 @@ view model =
     in
     case model.game.gameBoardStatus of
         NoGame _ ->
-            gameSelectionView model
+            Element.column [ Element.centerX, Element.centerY, Element.spacing 20 ]
+                [ Element.text "No active game"
+                , Input.button [ Background.color (Colors.primary model.theme), Border.solid, Element.paddingXY 12 10, Border.rounded 10, Font.color Colors.white ]
+                    { onPress = Just GoToStartPage
+                    , label = Element.text "Select a board"
+                    }
+                ]
 
         WaitOnStart initGameGrid ->
             let
@@ -334,38 +340,6 @@ view model =
                 Lazy.lazy3 finishedGameView boardConfig playGrid finishedStatus
 
 
-smallPlayground : PlayGroundDefinition
-smallPlayground =
-    { cols = 8
-    , rows = 8
-    , mines = 10
-    }
-
-
-mediumPlayground : PlayGroundDefinition
-mediumPlayground =
-    { cols = 16
-    , rows = 16
-    , mines = 40
-    }
-
-
-advancePlayground : PlayGroundDefinition
-advancePlayground =
-    { cols = 30
-    , rows = 16
-    , mines = 99
-    }
-
-
-xxlPlayground : PlayGroundDefinition
-xxlPlayground =
-    { cols = 30
-    , rows = 30
-    , mines = 200
-    }
-
-
 type alias BoardViewConfig =
     { cellSize : Int
     , cols : Int
@@ -383,54 +357,6 @@ boardViewConfig model cols rows =
     , isMobile = model.device.class == Phone || model.device.class == Tablet
     , theme = model.theme
     }
-
-
-gameSelectionView : Model -> Element GameMsg
-gameSelectionView model =
-    let
-        isPhone =
-            model.device.class == Phone
-
-        optionView : ( String, PlayGroundDefinition ) -> Element GameMsg
-        optionView ( title, definition ) =
-            Styles.styledGameSelectionButton model.theme
-                { onPress = Just (CreateNewGame definition)
-                , title = title
-                , subtitle =
-                    String.fromInt definition.cols
-                        ++ " x "
-                        ++ String.fromInt definition.rows
-                        ++ " • "
-                        ++ String.fromInt definition.mines
-                        ++ " mines"
-                , isPhone = isPhone
-                }
-
-        options =
-            [ ( "Small", smallPlayground )
-            , ( "Medium", mediumPlayground )
-            , ( "Advanced", advancePlayground )
-            , ( "XXL", xxlPlayground )
-            ]
-    in
-    Element.column
-        [ Element.width Element.fill
-        , Element.height Element.fill
-        , Element.padding 16
-        , Element.spacing 32
-        ]
-        [ Element.column [ Element.width Element.fill, Element.spacing 12, Font.center ]
-            [ Element.el [ Font.bold, Font.size 32, Element.centerX ] <| Element.text "Choose a board"
-            , Element.paragraph [ Font.color (Colors.textDim model.theme), Element.centerX, Element.width (Element.maximum 500 Element.fill) ]
-                [ Element.text "Mobile keeps touch-friendly cells and lets larger boards scroll when needed." ]
-            ]
-        , Element.wrappedRow
-            [ Element.centerX
-            , Element.spacing 16
-            , Element.width (Element.maximum 576 Element.fill)
-            ]
-            (List.map optionView options)
-        ]
 
 
 gameScreenLayout : Model -> BoardViewConfig -> Element GameMsg -> Element GameMsg

--- a/src/Game/Game.elm
+++ b/src/Game/Game.elm
@@ -307,13 +307,7 @@ view model =
     in
     case model.game.gameBoardStatus of
         NoGame _ ->
-            Element.column [ Element.centerX, Element.centerY, Element.spacing 20 ]
-                [ Element.text "No active game"
-                , Input.button [ Background.color (Colors.primary model.theme), Border.solid, Element.paddingXY 12 10, Border.rounded 10, Font.color Colors.white ]
-                    { onPress = Just GoToStartPage
-                    , label = Element.text "Select a board"
-                    }
-                ]
+            Element.none
 
         WaitOnStart initGameGrid ->
             let

--- a/src/Game/Game.elm
+++ b/src/Game/Game.elm
@@ -280,16 +280,13 @@ view model gameModel =
                 Resumed _ ->
                     Lazy.lazy2 runningGameView boardConfig playGrid
     in
-    case model.game.gameBoardStatus of
-        NoGame _ ->
-            Element.none
-
+    case gameModel.gameBoardStatus of
         WaitOnStart initGameGrid ->
             let
                 boardConfig =
                     boardConfigFromInitGrid initGameGrid
             in
-            gameScreenLayout model boardConfig <|
+            gameScreenLayout model gameModel boardConfig <|
                 Lazy.lazy2 initGameGridView boardConfig initGameGrid
 
         RunningGame playGrid ->
@@ -297,15 +294,15 @@ view model gameModel =
                 boardConfig =
                     boardConfigFromPlayGrid playGrid
             in
-            gameScreenLayout model boardConfig <|
-                gameGridElement boardConfig model.game.gamePauseResumeState playGrid
+            gameScreenLayout model gameModel boardConfig <|
+                gameGridElement boardConfig gameModel.gamePauseResumeState playGrid
 
         FinishedGame playGrid finishedStatus _ ->
             let
                 boardConfig =
                     boardConfigFromPlayGrid playGrid
             in
-            gameScreenLayout model boardConfig <|
+            gameScreenLayout model gameModel boardConfig <|
                 Lazy.lazy3 finishedGameView boardConfig playGrid finishedStatus
 
 
@@ -337,9 +334,9 @@ gameScreenLayout model gameModel boardConfig boardElement =
             , Element.padding 12
             , Element.spacing 12
             ]
-            [ mobileStatusBarElement model
+            [ mobileStatusBarElement model gameModel
             , Element.el [ Element.width Element.fill, Element.height Element.fill ] <| boardViewport boardConfig boardElement
-            , mobileActionBarElement model
+            , mobileActionBarElement model gameModel
             ]
 
     else
@@ -356,7 +353,7 @@ gameScreenLayout model gameModel boardConfig boardElement =
                 ]
               <|
                 boardViewport boardConfig boardElement
-            , sidebarElement model
+            , sidebarElement model gameModel
             ]
 
 
@@ -428,13 +425,13 @@ modeSelectorElements model gameModel =
                 ]
                 [ Element.el [ Font.bold, Element.centerY, Element.width (Element.px 130) ] <|
                     Element.text <|
-                        case model.game.gameInteractionMode of
+                        case gameModel.gameInteractionMode of
                             Reveal ->
                                 "Mode: Reveal"
 
                             Flag ->
                                 "Mode: Flag"
-                , Lazy.lazy2 mineToggleElement model.theme model.game.gameInteractionMode
+                , Lazy.lazy2 mineToggleElement model.theme gameModel.gameInteractionMode
                 ]
             ]
 
@@ -478,7 +475,7 @@ pauseToggleElements model gameModel =
                     desktopPauseButtonFontSize
             ]
     in
-    case ( model.game.gameBoardStatus, model.game.gamePauseResumeState ) of
+    case ( gameModel.gameBoardStatus, gameModel.gamePauseResumeState ) of
         ( RunningGame _, Paused ) ->
             [ Input.button buttonAttributes
                 { onPress = Just ToogleGamePause

--- a/src/Game/Selection.elm
+++ b/src/Game/Selection.elm
@@ -40,8 +40,8 @@ mediumPlayground =
     }
 
 
-advancePlayground : PlayGroundDefinition
-advancePlayground =
+advancedPlayground : PlayGroundDefinition
+advancedPlayground =
     { cols = 30
     , rows = 16
     , mines = 99
@@ -80,7 +80,7 @@ view model =
         options =
             [ ( "Small", smallPlayground )
             , ( "Medium", mediumPlayground )
-            , ( "Advanced", advancePlayground )
+            , ( "Advanced", advancedPlayground )
             , ( "XXL", xxlPlayground )
             ]
     in

--- a/src/Game/Selection.elm
+++ b/src/Game/Selection.elm
@@ -1,0 +1,104 @@
+{-
+   This file is part of Elm Minesweeper.
+
+   Elm Minesweeper is free software: you can redistribute it and/or modify it under
+   the terms of the GNU Affero General Public License as published by the Free Software
+   Foundation, either version 3 of the License, or (at your option) any later version.
+
+   Elm Minesweeper is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+   PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License along with
+   Elm Minesweeper. If not, see <https://www.gnu.org/licenses/>.
+
+-}
+
+
+module Game.Selection exposing (view)
+
+import Colors
+import Element exposing (Element)
+import Element.Font as Font
+import Styles
+import Types exposing (..)
+
+
+smallPlayground : PlayGroundDefinition
+smallPlayground =
+    { cols = 8
+    , rows = 8
+    , mines = 10
+    }
+
+
+mediumPlayground : PlayGroundDefinition
+mediumPlayground =
+    { cols = 16
+    , rows = 16
+    , mines = 40
+    }
+
+
+advancePlayground : PlayGroundDefinition
+advancePlayground =
+    { cols = 30
+    , rows = 16
+    , mines = 99
+    }
+
+
+xxlPlayground : PlayGroundDefinition
+xxlPlayground =
+    { cols = 30
+    , rows = 30
+    , mines = 200
+    }
+
+
+view : Model -> Element GameMsg
+view model =
+    let
+        isPhone =
+            model.device.class == Element.Phone
+
+        optionView : ( String, PlayGroundDefinition ) -> Element GameMsg
+        optionView ( title, definition ) =
+            Styles.styledGameSelectionButton model.theme
+                { onPress = Just (CreateNewGame definition)
+                , title = title
+                , subtitle =
+                    String.fromInt definition.cols
+                        ++ " x "
+                        ++ String.fromInt definition.rows
+                        ++ " • "
+                        ++ String.fromInt definition.mines
+                        ++ " mines"
+                , isPhone = isPhone
+                }
+
+        options =
+            [ ( "Small", smallPlayground )
+            , ( "Medium", mediumPlayground )
+            , ( "Advanced", advancePlayground )
+            , ( "XXL", xxlPlayground )
+            ]
+    in
+    Element.column
+        [ Element.width Element.fill
+        , Element.height Element.fill
+        , Element.padding 16
+        , Element.spacing 32
+        ]
+        [ Element.column [ Element.width Element.fill, Element.spacing 12, Font.center ]
+            [ Element.el [ Font.bold, Font.size 32, Element.centerX ] <| Element.text "Choose a board"
+            , Element.paragraph [ Font.color (Colors.textDim model.theme), Element.centerX, Element.width (Element.maximum 500 Element.fill) ]
+                [ Element.text "Mobile keeps touch-friendly cells and lets larger boards scroll when needed." ]
+            ]
+        , Element.wrappedRow
+            [ Element.centerX
+            , Element.spacing 16
+            , Element.width (Element.maximum 576 Element.fill)
+            ]
+            (List.map optionView options)
+        ]

--- a/src/Game/Selection.elm
+++ b/src/Game/Selection.elm
@@ -93,7 +93,7 @@ view model =
         [ Element.column [ Element.width Element.fill, Element.spacing 12, Font.center ]
             [ Element.el [ Font.bold, Font.size 32, Element.centerX ] <| Element.text "Choose a board"
             , Element.paragraph [ Font.color (Colors.textDim model.theme), Element.centerX, Element.width (Element.maximum 500 Element.fill) ]
-                [ Element.text "Mobile keeps touch-friendly cells and lets larger boards scroll when needed." ]
+                [ Element.text "Select a difficulty level to start playing. Larger boards contain more mines and offer a greater challenge." ]
             ]
         , Element.wrappedRow
             [ Element.centerX

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -111,13 +111,17 @@ update msg model =
                             { model | currentView = Game, game = Just newGameModel }
                     in
                     ( newModel
-                    , Navigation.pushUrl newModel.key
-                        (if newModel.containsGithubPrefixInPath then
-                            "/" ++ githubPagePathPrefix ++ "/game"
+                    , if model.currentView /= Game then
+                        Navigation.pushUrl newModel.key
+                            (if newModel.containsGithubPrefixInPath then
+                                "/" ++ githubPagePathPrefix ++ "/game"
 
-                         else
-                            "/game"
-                        )
+                             else
+                                "/game"
+                            )
+
+                      else
+                        Cmd.none
                     )
 
                 GoToStartPage ->

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -31,6 +31,7 @@ import Element.Region as Region
 import ErrorPage404
 import Game.Game as Game
 import Game.History as GameHistory
+import Game.Selection as GameSelection
 import Html.Attributes as HA
 import Ports
 import Theme exposing (Theme(..))
@@ -100,8 +101,41 @@ update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
         GameView gameMsg ->
-            Game.update gameMsg model
-                |> Tuple.mapSecond (Cmd.map GameView)
+            let
+                ( newModel, cmd ) =
+                    Game.update gameMsg model
+            in
+            case gameMsg of
+                CreateNewGame _ ->
+                    ( { newModel | currentView = Game }
+                    , Cmd.batch
+                        [ Cmd.map GameView cmd
+                        , Navigation.pushUrl newModel.key
+                            (if newModel.containsGithubPrefixInPath then
+                                "/" ++ githubPagePathPrefix ++ "/game"
+
+                             else
+                                "/game"
+                            )
+                        ]
+                    )
+
+                GoToStartPage ->
+                    ( { newModel | currentView = GameSelection }
+                    , Cmd.batch
+                        [ Cmd.map GameView cmd
+                        , Navigation.pushUrl newModel.key
+                            (if newModel.containsGithubPrefixInPath then
+                                "/" ++ githubPagePathPrefix ++ "/"
+
+                             else
+                                "/"
+                            )
+                        ]
+                    )
+
+                _ ->
+                    ( newModel, Cmd.map GameView cmd )
 
         GameHistory gameHistoryMsg ->
             GameHistory.update gameHistoryMsg model
@@ -137,8 +171,10 @@ update msg model =
 viewRouteParser : UP.Parser (View -> a) a
 viewRouteParser =
     UP.oneOf
-        [ UP.map Game UP.top
-        , UP.map Game (UP.s githubPagePathPrefix)
+        [ UP.map GameSelection UP.top
+        , UP.map GameSelection (UP.s githubPagePathPrefix)
+        , UP.map Game (UP.s "game")
+        , UP.map Game (UP.s githubPagePathPrefix </> UP.s "game")
         , UP.map gameHistoryQueryToView (UP.s "history" <?> GameHistory.queryParser)
         , UP.map gameHistoryQueryToView (UP.s githubPagePathPrefix </> UP.s "history" <?> GameHistory.queryParser)
         ]
@@ -192,7 +228,7 @@ init flags url key =
                     { width = flags.width
                     , height = flags.height
                     }
-            , currentView = Game
+            , currentView = GameSelection
             , game = Game.initModel
             , containsGithubPrefixInPath = flags.initPath |> hasGithubPathPrefix
             , playedGameHistory = Game.decodeStoredFinishedGameHistory flags.history
@@ -260,6 +296,14 @@ navigationView model =
 
             else
                 "/"
+
+        gameLinkPath =
+            case model.game.gameBoardStatus of
+                NoGame _ ->
+                    pathWithTrailingSlash
+
+                _ ->
+                    pathWithTrailingSlash ++ "game"
     in
     Element.wrappedRow
         [ Element.width Element.fill
@@ -282,7 +326,7 @@ navigationView model =
                             Dark ->
                                 "☀️"
                 }
-            , Element.link [ Font.color (Colors.textMain model.theme), Element.padding 12 ] { url = pathWithTrailingSlash ++ "", label = Element.text "Game" }
+            , Element.link [ Font.color (Colors.textMain model.theme), Element.padding 12 ] { url = gameLinkPath, label = Element.text "Game" }
             , Element.link [ Font.color (Colors.textMain model.theme), Element.padding 12 ] { url = pathWithTrailingSlash ++ "history", label = Element.text "History" }
             ]
         ]
@@ -339,6 +383,10 @@ footerView model =
 selectBoardView : Model -> Element Msg
 selectBoardView model =
     case model.currentView of
+        GameSelection ->
+            GameSelection.view model
+                |> Element.map GameView
+
         Game ->
             Game.view model
                 |> Element.map GameView

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -101,41 +101,51 @@ update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
         GameView gameMsg ->
-            let
-                ( newModel, cmd ) =
-                    Game.update gameMsg model
-            in
             case gameMsg of
-                CreateNewGame _ ->
-                    ( { newModel | currentView = Game }
-                    , Cmd.batch
-                        [ Cmd.map GameView cmd
-                        , Navigation.pushUrl newModel.key
-                            (if newModel.containsGithubPrefixInPath then
-                                "/" ++ githubPagePathPrefix ++ "/game"
+                CreateNewGame definition ->
+                    let
+                        newGameModel =
+                            Game.initModel definition
 
-                             else
-                                "/game"
-                            )
-                        ]
+                        newModel =
+                            { model | currentView = Game, game = Just newGameModel }
+                    in
+                    ( newModel
+                    , Navigation.pushUrl newModel.key
+                        (if newModel.containsGithubPrefixInPath then
+                            "/" ++ githubPagePathPrefix ++ "/game"
+
+                         else
+                            "/game"
+                        )
                     )
 
                 GoToStartPage ->
-                    ( { newModel | currentView = GameSelection }
-                    , Cmd.batch
-                        [ Cmd.map GameView cmd
-                        , Navigation.pushUrl newModel.key
-                            (if newModel.containsGithubPrefixInPath then
-                                "/" ++ githubPagePathPrefix ++ "/"
+                    let
+                        newModel =
+                            { model | currentView = GameSelection, game = Nothing }
+                    in
+                    ( newModel
+                    , Navigation.pushUrl newModel.key
+                        (if newModel.containsGithubPrefixInPath then
+                            "/" ++ githubPagePathPrefix ++ "/"
 
-                             else
-                                "/"
-                            )
-                        ]
+                         else
+                            "/"
+                        )
                     )
 
                 _ ->
-                    ( newModel, Cmd.map GameView cmd )
+                    case model.game of
+                        Just gameModel ->
+                            let
+                                ( newModel, cmd ) =
+                                    Game.update gameMsg gameModel model
+                            in
+                            ( newModel, Cmd.map GameView cmd )
+
+                        Nothing ->
+                            ( model, Cmd.none )
 
         GameHistory gameHistoryMsg ->
             GameHistory.update gameHistoryMsg model
@@ -202,8 +212,8 @@ navigationHandling request model =
                             ( model, Cmd.none )
 
                         else
-                            case ( parsedView, model.game.gameBoardStatus ) of
-                                ( Game, NoGame _ ) ->
+                            case ( parsedView, model.game ) of
+                                ( Game, Nothing ) ->
                                     ( { model | currentView = GameSelection }
                                     , Navigation.replaceUrl model.key
                                         (if model.containsGithubPrefixInPath then
@@ -215,14 +225,21 @@ navigationHandling request model =
                                     )
 
                                 _ ->
-                                    Game.update (NavigationEvent parsedView) model
-                                        |> Tuple.mapBoth
-                                            (\m -> { m | currentView = parsedView })
-                                            (\cmd ->
-                                                Cmd.batch
-                                                    [ Cmd.map GameView cmd
-                                                    , Navigation.pushUrl model.key (Url.toString url)
-                                                    ]
+                                    case model.game of
+                                        Just gameModel ->
+                                            Game.update (NavigationEvent parsedView) gameModel model
+                                                |> Tuple.mapBoth
+                                                    (\newModel -> { newModel | currentView = parsedView })
+                                                    (\cmd ->
+                                                        Cmd.batch
+                                                            [ Cmd.map GameView cmd
+                                                            , Navigation.pushUrl model.key (Url.toString url)
+                                                            ]
+                                                    )
+
+                                        Nothing ->
+                                            ( { model | currentView = parsedView }
+                                            , Navigation.pushUrl model.key (Url.toString url)
                                             )
                    )
 
@@ -268,7 +285,12 @@ hasGithubPathPrefix initPath =
 subscriptions : Model -> Sub Msg
 subscriptions model =
     Sub.batch
-        [ Sub.map GameView (Game.subscriptions model)
+        [ case model.game of
+            Just gameModel ->
+                Sub.map GameView (Game.subscriptions model gameModel)
+
+            Nothing ->
+                Sub.none
         , Events.onResize (\values -> SetScreenSize values)
         ]
 
@@ -311,11 +333,11 @@ navigationView model =
                 "/"
 
         gameLinkPath =
-            case model.game.gameBoardStatus of
-                NoGame _ ->
+            case model.game of
+                Nothing ->
                     pathWithTrailingSlash
 
-                _ ->
+                Just _ ->
                     pathWithTrailingSlash ++ "game"
     in
     Element.wrappedRow
@@ -401,8 +423,13 @@ selectBoardView model =
                 |> Element.map GameView
 
         Game ->
-            Game.view model
-                |> Element.map GameView
+            case model.game of
+                Just gameModel ->
+                    Game.view model gameModel
+                        |> Element.map GameView
+
+                Nothing ->
+                    Element.none
 
         Error404 ->
             ErrorPage404.view model

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -242,7 +242,7 @@ init flags url key =
                     , height = flags.height
                     }
             , currentView = GameSelection
-            , game = Game.initModel
+            , game = Nothing
             , containsGithubPrefixInPath = flags.initPath |> hasGithubPathPrefix
             , playedGameHistory = Game.decodeStoredFinishedGameHistory flags.history
             , theme =

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -202,15 +202,28 @@ navigationHandling request model =
                             ( model, Cmd.none )
 
                         else
-                            Game.update (NavigationEvent parsedView) model
-                                |> Tuple.mapBoth
-                                    (\m -> { m | currentView = parsedView })
-                                    (\cmd ->
-                                        Cmd.batch
-                                            [ Cmd.map GameView cmd
-                                            , Navigation.pushUrl model.key (Url.toString url)
-                                            ]
+                            case ( parsedView, model.game.gameBoardStatus ) of
+                                ( Game, NoGame _ ) ->
+                                    ( { model | currentView = GameSelection }
+                                    , Navigation.replaceUrl model.key
+                                        (if model.containsGithubPrefixInPath then
+                                            "/" ++ githubPagePathPrefix ++ "/"
+
+                                         else
+                                            "/"
+                                        )
                                     )
+
+                                _ ->
+                                    Game.update (NavigationEvent parsedView) model
+                                        |> Tuple.mapBoth
+                                            (\m -> { m | currentView = parsedView })
+                                            (\cmd ->
+                                                Cmd.batch
+                                                    [ Cmd.map GameView cmd
+                                                    , Navigation.pushUrl model.key (Url.toString url)
+                                                    ]
+                                            )
                    )
 
         External url ->

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -149,12 +149,6 @@ type GameBoardStatus
     = WaitOnStart InitGameData
     | RunningGame PlayGameGrid
     | FinishedGame PlayGameGrid GameResult Int
-    | NoGame NoGameMode
-
-
-type NoGameMode
-    = PreSelect
-    | Custom
 
 
 type alias InitGameData =

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -107,7 +107,8 @@ type alias GameModel =
 
 
 type View
-    = Game
+    = GameSelection
+    | Game
     | History GameHistoryDisplayMode GameHistoryOrderBy OrderDirection
     | Error404
 

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -87,7 +87,7 @@ type OrderDirection
 
 
 type alias Model =
-    { game : GameModel
+    { game : Maybe GameModel
     , playedGameHistory : List FinishedGameHistoryEntry
     , currentView : View
     , device : Device


### PR DESCRIPTION
# Architectural Refactor: Explicit Game Lifecycle with `Maybe GameModel`

This PR completes the separation of game selection from gameplay and introduces a robust architectural pattern for managing the game's lifecycle.

## Key Changes

### 1. Separation of Concerns
- Moved the game selection UI into its own `Game/Selection.elm` view.
- Decoupled `Game.elm` from game selection logic, focusing it entirely on active gameplay.

### 2. Elimination of Impossible States (`Maybe GameModel`)
- Refactored the core application state to use `Maybe GameModel` instead of a model containing a `NoGame` variant. 
- Removed the `NoGame` constructor from `GameBoardStatus` and deleted the `NoGameMode` type.
- This transition ensures that if a `GameModel` exists, it is in a valid state (Waiting, Running, or Finished).

### 3. Lifecycle Management in `Main.elm`
- `Main.elm` now explicitly manages the creation and destruction of the `GameModel`.
- The `Game` route now performs an automatic redirect to the selection screen if no active game exists, preventing access to "zombie" states.
- Subscriptions and views are now conditionally mapped based on the presence of the game model.

### 4. Code Robustness & Cleanup
- Removed redundant pattern matching for the defunct `NoGame` state across the codebase.
- Simplified `Game.elm` functions by passing the guaranteed `GameModel` directly.
- Verified all changes with the test suite.

This refactor significantly improves code maintainability and prevents a class of potential bugs by making invalid application states unrepresentable in the type system.