### PR TITLE
feat: persist running game with salted checksum and offer resume tile

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -43,13 +43,19 @@ The goal of this project is to provide a fully functional, visually polished Min
 - **Theming:** Dynamic dark/light theme switch support.
 - **Game History:** A dedicated view to browse past games, filterable by result (Won/Lost) and sortable by duration, date, or difficulty.
 - **Visual Feedback:** Interactive feedback for cell hovering, clicking, and state changes (Reveal vs. Flag mode).
+- **Resume:** An interrupted running game survives reloads and navigation. It is offered as a resume tile at the top of the selection view; until resumed the game counts as paused.
 
 ## 5. Persistence Schema
-Data is persisted as a JSON string in `localStorage` under the key `finishedGameHistory`.
+Data is persisted as JSON strings in `localStorage` under two keys: `finishedGameHistory` (completed games) and `runningGame` (the in-progress game, saved on every clock tick).
 
-### Versioning
+### Finished Game History (`finishedGameHistory`)
 - **Version 1 (Current):** Includes `grid`, `result` ("won"/"lost"), `duration` (ms), and `posix` (timestamp).
 - **Migration:** The application includes decoders to transparently upgrade Version 0 (legacy) data to the current schema.
+
+### Running Game (`runningGame`)
+- **Version 1 (Current):** Envelope `{ "version": 1, "checksum": <int>, "game": { "grid": [...], "runningTimes": [{"start": <ms>, "end": <ms>}, ...], "lastClockTick": <ms>, "interactionMode": "reveal"|"flag" } }`.
+- **Integrity:** `checksum` is a salted djb2 (32-bit) hash over the compact JSON encoding of `game`, covering the board and the elapsed time segments. The salt combines a static application salt with a random per-browser salt (`runningGameSalt` key, generated on first start), so a valid checksum cannot be derived from the source code alone and saves are not portable between browsers. This protects against casual manual editing of `localStorage`, not against determined tampering — without a server, cryptographic integrity is out of reach by design. On load the game is decoded, canonically re-encoded and re-hashed; any mismatch, unknown version, or decode failure discards the save and removes the key.
+- **Lifecycle:** Written on game start, every clock tick, cell interactions, and pause transitions; removed when the game finishes, is given up, or a new game is created. A restored game always starts paused; the player resumes it from the selection view. With multiple open tabs the last writer wins.
 
 ## 6. File Map
 
@@ -71,3 +77,4 @@ Data is persisted as a JSON string in `localStorage` under the key `finishedGame
 - `src/Ports.elm`: Elm-to-JS communication for persistence.
 - `public/`: Static assets (index.html, manifest, icons, background images).
 - `tests/GameTests.elm`: Test suite for grid logic and decoders.
+- `tests/RunningGamePersistenceTests.elm`: Test suite for the running game snapshot codec and checksum.

--- a/src/Game/Game.elm
+++ b/src/Game/Game.elm
@@ -15,7 +15,7 @@
 -}
 
 
-module Game.Game exposing (decodeStoredFinishedGameHistory, initModel, subscriptions, update, view)
+module Game.Game exposing (decodeStoredFinishedGameHistory, decodeStoredRunningGame, initModel, resumeGame, subscriptions, update, view)
 
 {-| Game module for rendering the complete game, as long as the currentView in the model is set to Game.
 Exposes the basic update / view / subscription functions, so that Main.elm can use them.
@@ -62,6 +62,26 @@ decodeStoredFinishedGameHistory : String -> List FinishedGameHistoryEntry
 decodeStoredFinishedGameHistory string =
     Decode.decodeString decodeFinishedGameHistory string
         |> Result.withDefault []
+
+
+decodeStoredRunningGame : String -> String -> Maybe GameModel
+decodeStoredRunningGame browserSalt string =
+    Decode.decodeString (decodeRunningGameEnvelope browserSalt) string
+        |> Result.toMaybe
+
+
+{-| Resumes a paused running game by opening a fresh time segment. The Resumed
+counter must stay one ahead of the recorded segments so that the next ClockTick
+starts a new segment instead of extending the last one (see updateTimePlayGame).
+-}
+resumeGame : GameModel -> GameModel
+resumeGame gameModel =
+    case ( gameModel.gameBoardStatus, gameModel.gamePauseResumeState ) of
+        ( RunningGame _, Paused ) ->
+            { gameModel | gamePauseResumeState = Resumed (List.length gameModel.gameRunningTimes + 1) }
+
+        _ ->
+            gameModel
 
 
 subscriptions : Model -> GameModel -> Sub GameMsg
@@ -119,9 +139,16 @@ update gameMsg gameModel model =
             ( model, generatePlayGameGrid initGame coords |> Random.generate StartGame )
 
         StartGame playGrid ->
-            ( { model | game = Just { gameModel | gameBoardStatus = RunningGame playGrid, gameRunningTimes = [], gamePauseResumeState = Resumed 1 } }, Cmd.none )
+            let
+                newGameModel =
+                    { gameModel | gameBoardStatus = RunningGame playGrid, gameRunningTimes = [], gamePauseResumeState = Resumed 1 }
+            in
+            ( { model | game = Just newGameModel }, saveRunningGame model.runningGameSalt newGameModel )
 
         CreateNewGame _ ->
+            ( model, Cmd.none )
+
+        ResumeSavedGame ->
             ( model, Cmd.none )
 
         ClickOnGameCell coords ->
@@ -140,7 +167,11 @@ update gameMsg gameModel model =
             ( { model | game = Just { gameModel | gameInteractionMode = nextMode } }, Cmd.none )
 
         ToogleGamePause ->
-            ( togglePause gameModel model, Cmd.none )
+            let
+                newModel =
+                    togglePause gameModel model
+            in
+            ( newModel, saveRunningGameOf newModel )
 
         ClockTick posix ->
             updateTimePlayGame gameModel model posix
@@ -151,7 +182,11 @@ update gameMsg gameModel model =
                     ( model, Cmd.none )
 
                 ( Game, _ ) ->
-                    ( togglePause gameModel model, Cmd.none )
+                    let
+                        newModel =
+                            togglePause gameModel model
+                    in
+                    ( newModel, saveRunningGameOf newModel )
 
                 ( _, Game ) ->
                     ( togglePause gameModel model, Cmd.none )
@@ -160,11 +195,20 @@ update gameMsg gameModel model =
                     ( model, Cmd.none )
 
 
+{-| Persists the current running game of the top level model, if there is one.
+-}
+saveRunningGameOf : Model -> Cmd GameMsg
+saveRunningGameOf model =
+    model.game
+        |> Maybe.map (saveRunningGame model.runningGameSalt)
+        |> Maybe.withDefault Cmd.none
+
+
 togglePause : GameModel -> Model -> Model
 togglePause gameModel model =
     case ( gameModel.gameBoardStatus, gameModel.gamePauseResumeState ) of
         ( RunningGame _, Paused ) ->
-            { model | game = Just { gameModel | gamePauseResumeState = Resumed (List.length gameModel.gameRunningTimes + 1) } }
+            { model | game = Just (resumeGame gameModel) }
 
         ( RunningGame _, Resumed _ ) ->
             { model | game = Just { gameModel | gamePauseResumeState = Paused } }
@@ -192,8 +236,11 @@ updateTimePlayGame gameModel model time =
 
                     else
                         ( time, time ) :: gameModel.gameRunningTimes
+
+                newGameModel =
+                    { gameModel | gameRunningTimes = newList, lastClockTick = time }
             in
-            ( { model | game = Just { gameModel | gameRunningTimes = newList, lastClockTick = time } }, Cmd.none )
+            ( { model | game = Just newGameModel }, saveRunningGame model.runningGameSalt newGameModel )
 
         _ ->
             ( model, Cmd.none )
@@ -241,8 +288,19 @@ updateModelByClickOnGameCell coords gameModel model =
 
                         _ ->
                             model.playedGameHistory
+
+                nextGameModel =
+                    { gameModel | gameBoardStatus = nextGameBoardStatus }
+
+                persistCmd =
+                    case nextGameBoardStatus of
+                        FinishedGame _ _ _ ->
+                            Cmd.batch [ saveFinishedGameHistory nextHistoryList, clearRunningGame ]
+
+                        _ ->
+                            saveRunningGame model.runningGameSalt nextGameModel
             in
-            ( { model | game = Just { gameModel | gameBoardStatus = nextGameBoardStatus }, playedGameHistory = nextHistoryList }, saveFinishedGameHistory nextHistoryList )
+            ( { model | game = Just nextGameModel, playedGameHistory = nextHistoryList }, persistCmd )
 
         _ ->
             ( model, Cmd.none )
@@ -747,24 +805,6 @@ createInitGameGrid definition =
     }
 
 
-playGameGridToPlaygroundDefinition : PlayGameGrid -> PlayGroundDefinition
-playGameGridToPlaygroundDefinition grid =
-    let
-        foldLFn : GameCell -> Int -> Int
-        foldLFn cell count =
-            case cell of
-                GameCell MineCell _ ->
-                    count + 1
-
-                _ ->
-                    count
-    in
-    { cols = Grid.width grid
-    , rows = Grid.height grid
-    , mines = Grid.foldl foldLFn 0 grid
-    }
-
-
 sanitizePlaygroundDefinition : PlayGroundDefinition -> PlayGroundDefinition
 sanitizePlaygroundDefinition definition =
     let
@@ -915,11 +955,6 @@ minesIndexGenerator remainingMines remainingPossibilities alreadyGenerated =
                                 in
                                 minesIndexGenerator newRemainingMines newRemainingPossibilities (Random.constant set)
                             )
-
-
-calculateElapsedTimeMillis : List ( Time.Posix, Time.Posix ) -> Int
-calculateElapsedTimeMillis =
-    List.foldl (\( from, to ) summedUp -> (Time.posixToMillis to - Time.posixToMillis from) + summedUp) 0
 
 
 appendGenerator : Generator (Set Int) -> Generator Int -> Generator (Set Int)

--- a/src/Game/Internal.elm
+++ b/src/Game/Internal.elm
@@ -334,12 +334,13 @@ staticChecksumSalt =
     "elm-minesweeper-running-game-v1"
 
 
-{-| djb2 hash (xor variant) over the UTF-16 code units of a string.
+{-| djb2 hash (xor variant) over the Unicode code points of a string.
 
     The accumulator is normalized to [0, 2^32) via shiftRightZfBy 0 after every
     step, so the intermediate product hash * 33 stays below 2^38 and therefore
     within the exactly representable Int range. Bitwise.xor truncates the
-    product to 32 bits before the unsigned normalization.
+    product to 32 bits before the unsigned normalization; the xor'd code point
+    stays below 2^21 (max 0x10FFFF) and cannot widen the result.
 
 -}
 djb2Hash : String -> Int
@@ -485,9 +486,17 @@ runningGameSnapshotDecoder =
 
 decodeTimeSegment : Decoder ( Time.Posix, Time.Posix )
 decodeTimeSegment =
-    Decode.map2 (\start end -> ( Time.millisToPosix start, Time.millisToPosix end ))
+    Decode.map2 Tuple.pair
         (Decode.field "start" Decode.int)
         (Decode.field "end" Decode.int)
+        |> Decode.andThen
+            (\( start, end ) ->
+                if start > end then
+                    Decode.fail "Time segment must not end before it starts"
+
+                else
+                    Decode.succeed ( Time.millisToPosix start, Time.millisToPosix end )
+            )
 
 
 decodeInteractionMode : Decoder CellClickMode

--- a/src/Game/Internal.elm
+++ b/src/Game/Internal.elm
@@ -29,6 +29,7 @@ module Game.Internal exposing (..)
 
 -}
 
+import Bitwise
 import Grid exposing (Grid)
 import Json.Decode as Decode exposing (Decoder)
 import Json.Encode as Encode
@@ -326,6 +327,207 @@ saveFinishedGameHistory : List FinishedGameHistoryEntry -> Cmd msg
 saveFinishedGameHistory finishedGameHistory =
     encodeFinishedGameHistory finishedGameHistory
         |> Ports.storeFinishedGameHistory
+
+
+staticChecksumSalt : String
+staticChecksumSalt =
+    "elm-minesweeper-running-game-v1"
+
+
+{-| djb2 hash (xor variant) over the UTF-16 code units of a string.
+
+    The accumulator is normalized to [0, 2^32) via shiftRightZfBy 0 after every
+    step, so the intermediate product hash * 33 stays below 2^38 and therefore
+    within the exactly representable Int range. Bitwise.xor truncates the
+    product to 32 bits before the unsigned normalization.
+
+-}
+djb2Hash : String -> Int
+djb2Hash =
+    String.foldl
+        (\char hash ->
+            (hash * 33)
+                |> Bitwise.xor (Char.toCode char)
+                |> Bitwise.shiftRightZfBy 0
+        )
+        5381
+
+
+{-| Salted checksum over the compact JSON encoding of a running game. Guards the
+stored game (board and elapsed time segments alike) against casual manual edits
+in localStorage - determined tampering is out of scope for a pure SPA. The
+browser salt is generated randomly on first app start and kept in localStorage,
+so a valid checksum cannot be derived from the source code alone and saves are
+not portable between browsers.
+-}
+runningGameChecksum : String -> String -> Int
+runningGameChecksum browserSalt payload =
+    djb2Hash (staticChecksumSalt ++ browserSalt ++ payload)
+
+
+runningGameValue : PlayGameGrid -> GameModel -> Encode.Value
+runningGameValue grid gameModel =
+    Encode.object
+        [ ( "grid", Grid.rows grid |> Encode.array (Encode.array gameCellEncoder) )
+        , ( "runningTimes"
+          , Encode.list
+                (\( start, end ) ->
+                    Encode.object
+                        [ ( "start", Encode.int (Time.posixToMillis start) )
+                        , ( "end", Encode.int (Time.posixToMillis end) )
+                        ]
+                )
+                gameModel.gameRunningTimes
+          )
+        , ( "lastClockTick", Encode.int (Time.posixToMillis gameModel.lastClockTick) )
+        , ( "interactionMode"
+          , Encode.string
+                (case gameModel.gameInteractionMode of
+                    Reveal ->
+                        "reveal"
+
+                    Flag ->
+                        "flag"
+                )
+          )
+        ]
+
+
+encodeRunningGame : String -> GameModel -> Maybe String
+encodeRunningGame browserSalt gameModel =
+    case gameModel.gameBoardStatus of
+        RunningGame grid ->
+            let
+                gameValue =
+                    runningGameValue grid gameModel
+            in
+            Encode.object
+                [ ( "version", Encode.int 1 )
+                , ( "checksum", Encode.int (runningGameChecksum browserSalt (Encode.encode 0 gameValue)) )
+                , ( "game", gameValue )
+                ]
+                |> Encode.encode 0
+                |> Just
+
+        _ ->
+            Nothing
+
+
+saveRunningGame : String -> GameModel -> Cmd msg
+saveRunningGame browserSalt gameModel =
+    encodeRunningGame browserSalt gameModel
+        |> Maybe.map Ports.storeRunningGame
+        |> Maybe.withDefault Cmd.none
+
+
+clearRunningGame : Cmd msg
+clearRunningGame =
+    Ports.clearRunningGame ()
+
+
+{-| Decodes the versioned envelope around a stored running game. The game is
+decoded first, canonically re-encoded and re-hashed; any checksum mismatch,
+unknown version or malformed payload rejects the whole save.
+-}
+decodeRunningGameEnvelope : String -> Decoder GameModel
+decodeRunningGameEnvelope browserSalt =
+    Decode.map2 Tuple.pair
+        (Decode.field "version" Decode.int
+            |> Decode.andThen
+                (\v ->
+                    if v == 1 then
+                        Decode.succeed v
+
+                    else
+                        Decode.fail "Unsupported running game version"
+                )
+        )
+        (Decode.field "checksum" Decode.int)
+        |> Decode.andThen
+            (\( _, expectedChecksum ) ->
+                Decode.field "game" runningGameSnapshotDecoder
+                    |> Decode.andThen
+                        (\gameModel ->
+                            case gameModel.gameBoardStatus of
+                                RunningGame grid ->
+                                    if runningGameChecksum browserSalt (Encode.encode 0 (runningGameValue grid gameModel)) == expectedChecksum then
+                                        Decode.succeed gameModel
+
+                                    else
+                                        Decode.fail "Running game checksum mismatch"
+
+                                _ ->
+                                    Decode.fail "Stored game is not a running game"
+                        )
+            )
+
+
+{-| A restored game is always paused - the player resumes it explicitly from the
+selection view, which keeps the pause/segment invariant of updateTimePlayGame
+intact.
+-}
+runningGameSnapshotDecoder : Decoder GameModel
+runningGameSnapshotDecoder =
+    Decode.map4
+        (\grid times tick mode ->
+            { gameBoardStatus = RunningGame grid
+            , gameInteractionMode = mode
+            , gameRunningTimes = times
+            , gamePauseResumeState = Paused
+            , lastClockTick = Time.millisToPosix tick
+            }
+        )
+        (Decode.field "grid" decodeGrid)
+        (Decode.field "runningTimes" (Decode.list decodeTimeSegment))
+        (Decode.field "lastClockTick" Decode.int)
+        (Decode.field "interactionMode" decodeInteractionMode)
+
+
+decodeTimeSegment : Decoder ( Time.Posix, Time.Posix )
+decodeTimeSegment =
+    Decode.map2 (\start end -> ( Time.millisToPosix start, Time.millisToPosix end ))
+        (Decode.field "start" Decode.int)
+        (Decode.field "end" Decode.int)
+
+
+decodeInteractionMode : Decoder CellClickMode
+decodeInteractionMode =
+    Decode.string
+        |> Decode.andThen
+            (\modeAsString ->
+                case modeAsString of
+                    "reveal" ->
+                        Decode.succeed Reveal
+
+                    "flag" ->
+                        Decode.succeed Flag
+
+                    _ ->
+                        Decode.fail "Invalid interaction mode"
+            )
+
+
+calculateElapsedTimeMillis : List ( Time.Posix, Time.Posix ) -> Int
+calculateElapsedTimeMillis =
+    List.foldl (\( from, to ) summedUp -> (Time.posixToMillis to - Time.posixToMillis from) + summedUp) 0
+
+
+playGameGridToPlaygroundDefinition : PlayGameGrid -> PlayGroundDefinition
+playGameGridToPlaygroundDefinition grid =
+    let
+        foldLFn : GameCell -> Int -> Int
+        foldLFn cell count =
+            case cell of
+                GameCell MineCell _ ->
+                    count + 1
+
+                _ ->
+                    count
+    in
+    { cols = Grid.width grid
+    , rows = Grid.height grid
+    , mines = Grid.foldl foldLFn 0 grid
+    }
 
 
 millisToString : Int -> String

--- a/src/Game/Selection.elm
+++ b/src/Game/Selection.elm
@@ -20,6 +20,7 @@ module Game.Selection exposing (view)
 import Colors
 import Element exposing (Element)
 import Element.Font as Font
+import Game.Internal as GameInternal
 import Styles
 import Types exposing (..)
 
@@ -90,15 +91,57 @@ view model =
         , Element.padding 16
         , Element.spacing 32
         ]
-        [ Element.column [ Element.width Element.fill, Element.spacing 12, Font.center ]
+        ([ Element.column [ Element.width Element.fill, Element.spacing 12, Font.center ]
             [ Element.el [ Font.bold, Font.size 32, Element.centerX ] <| Element.text "Choose a board"
             , Element.paragraph [ Font.color (Colors.textDim model.theme), Element.centerX, Element.width (Element.maximum 500 Element.fill) ]
                 [ Element.text "Select a difficulty level to start playing. Larger boards contain more mines and offer a greater challenge." ]
             ]
-        , Element.wrappedRow
-            [ Element.centerX
-            , Element.spacing 16
-            , Element.width (Element.maximum 576 Element.fill)
-            ]
-            (List.map optionView options)
-        ]
+         ]
+            ++ resumeSection model
+            ++ [ Element.wrappedRow
+                    [ Element.centerX
+                    , Element.spacing 16
+                    , Element.width (Element.maximum 576 Element.fill)
+                    ]
+                    (List.map optionView options)
+               ]
+        )
+
+
+{-| Offers to resume a stored, interrupted game. Rendered above the difficulty
+tiles as the first tappable element, or not at all when no saved game exists.
+-}
+resumeSection : Model -> List (Element GameMsg)
+resumeSection model =
+    case model.savedGame of
+        Just savedGame ->
+            case savedGame.gameBoardStatus of
+                RunningGame grid ->
+                    let
+                        definition =
+                            GameInternal.playGameGridToPlaygroundDefinition grid
+
+                        elapsedTime =
+                            GameInternal.calculateElapsedTimeMillis savedGame.gameRunningTimes
+                    in
+                    [ Element.el [ Element.centerX, Element.width (Element.maximum 576 Element.fill) ] <|
+                        Styles.styledResumeGameButton model.theme
+                            { onPress = Just ResumeSavedGame
+                            , title = "Resume game"
+                            , subtitle =
+                                String.fromInt definition.cols
+                                    ++ " x "
+                                    ++ String.fromInt definition.rows
+                                    ++ " • "
+                                    ++ String.fromInt definition.mines
+                                    ++ " mines • "
+                                    ++ GameInternal.millisToString elapsedTime
+                                    ++ " played"
+                            }
+                    ]
+
+                _ ->
+                    []
+
+        Nothing ->
+            []

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -108,35 +108,65 @@ update msg model =
                             Game.initModel definition
 
                         newModel =
-                            { model | currentView = Game, game = Just newGameModel }
+                            { model | currentView = Game, game = Just newGameModel, savedGame = Nothing }
                     in
                     ( newModel
-                    , if model.currentView /= Game then
-                        Navigation.pushUrl newModel.key
-                            (if newModel.containsGithubPrefixInPath then
-                                "/" ++ githubPagePathPrefix ++ "/game"
+                    , Cmd.batch
+                        [ if model.currentView /= Game then
+                            Navigation.pushUrl newModel.key
+                                (if newModel.containsGithubPrefixInPath then
+                                    "/" ++ githubPagePathPrefix ++ "/game"
 
-                             else
-                                "/game"
+                                 else
+                                    "/game"
+                                )
+
+                          else
+                            Cmd.none
+                        , Ports.clearRunningGame ()
+                        ]
+                    )
+
+                ResumeSavedGame ->
+                    case model.savedGame of
+                        Just savedGame ->
+                            let
+                                newModel =
+                                    { model | currentView = Game, game = Just (Game.resumeGame savedGame), savedGame = Nothing }
+                            in
+                            ( newModel
+                            , if model.currentView /= Game then
+                                Navigation.pushUrl newModel.key
+                                    (if newModel.containsGithubPrefixInPath then
+                                        "/" ++ githubPagePathPrefix ++ "/game"
+
+                                     else
+                                        "/game"
+                                    )
+
+                              else
+                                Cmd.none
                             )
 
-                      else
-                        Cmd.none
-                    )
+                        Nothing ->
+                            ( model, Cmd.none )
 
                 GoToStartPage ->
                     let
                         newModel =
-                            { model | currentView = GameSelection, game = Nothing }
+                            { model | currentView = GameSelection, game = Nothing, savedGame = Nothing }
                     in
                     ( newModel
-                    , Navigation.pushUrl newModel.key
-                        (if newModel.containsGithubPrefixInPath then
-                            "/" ++ githubPagePathPrefix ++ "/"
+                    , Cmd.batch
+                        [ Navigation.pushUrl newModel.key
+                            (if newModel.containsGithubPrefixInPath then
+                                "/" ++ githubPagePathPrefix ++ "/"
 
-                         else
-                            "/"
-                        )
+                             else
+                                "/"
+                            )
+                        , Ports.clearRunningGame ()
+                        ]
                     )
 
                 _ ->
@@ -254,6 +284,10 @@ navigationHandling request model =
 init : Flags -> Url -> Key -> ( Model, Cmd Msg )
 init flags url key =
     let
+        savedGame : Maybe GameModel
+        savedGame =
+            Game.decodeStoredRunningGame flags.runningGameSalt flags.runningGame
+
         basicInitModel : Model
         basicInitModel =
             { key = key
@@ -264,6 +298,7 @@ init flags url key =
                     }
             , currentView = GameSelection
             , game = Nothing
+            , savedGame = savedGame
             , containsGithubPrefixInPath = flags.initPath |> hasGithubPathPrefix
             , playedGameHistory = Game.decodeStoredFinishedGameHistory flags.history
             , theme =
@@ -272,13 +307,25 @@ init flags url key =
 
                 else
                     Dark
+            , runningGameSalt = flags.runningGameSalt
             }
 
         navigationMsg : Msg
         navigationMsg =
             Navigation (Internal url)
+
+        ( initializedModel, initCmd ) =
+            update navigationMsg basicInitModel
+
+        staleSaveCleanup : Cmd Msg
+        staleSaveCleanup =
+            if flags.runningGame /= "" && savedGame == Nothing then
+                Ports.clearRunningGame ()
+
+            else
+                Cmd.none
     in
-    update navigationMsg basicInitModel
+    ( initializedModel, Cmd.batch [ initCmd, staleSaveCleanup ] )
 
 
 hasGithubPathPrefix : String -> Bool

--- a/src/Ports.elm
+++ b/src/Ports.elm
@@ -15,10 +15,16 @@
 -}
 
 
-port module Ports exposing (storeFinishedGameHistory, storeTheme)
+port module Ports exposing (clearRunningGame, storeFinishedGameHistory, storeRunningGame, storeTheme)
 
 
 port storeFinishedGameHistory : String -> Cmd msg
+
+
+port storeRunningGame : String -> Cmd msg
+
+
+port clearRunningGame : () -> Cmd msg
 
 
 port storeTheme : String -> Cmd msg

--- a/src/Styles.elm
+++ b/src/Styles.elm
@@ -271,6 +271,27 @@ styledGameSelectionButton theme { onPress, title, subtitle, isPhone } =
         }
 
 
+styledResumeGameButton : Theme -> { onPress : Maybe msg, title : String, subtitle : String } -> Element msg
+styledResumeGameButton theme { onPress, title, subtitle } =
+    Input.button
+        [ Element.width fill
+        , Element.padding 20
+        , Background.color (Colors.surface theme)
+        , Border.rounded 16
+        , Border.color (Colors.primary theme)
+        , Border.width 2
+        , Element.centerX
+        , Font.color (Colors.textMain theme)
+        ]
+        { onPress = onPress
+        , label =
+            column [ Element.width fill, Element.spacing 8 ]
+                [ el [ Font.bold, Font.size 24 ] <| text (icons.resume ++ " " ++ title)
+                , el [ Font.color (Colors.textDim theme) ] <| text subtitle
+                ]
+        }
+
+
 pillBadge : Theme -> String -> Element msg
 pillBadge theme label =
     Element.el

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -41,6 +41,8 @@ type alias Flags =
     , history : String
     , initPath : String
     , theme : String
+    , runningGame : String
+    , runningGameSalt : String
     }
 
 
@@ -53,6 +55,7 @@ type GameMsg
     | ClickOnGameCell Coordinate
     | ToogleGameCellInteractionMode
     | CreateNewGame PlayGroundDefinition
+    | ResumeSavedGame
     | GoToStartPage
     | ClockTick Time.Posix
     | ToogleGamePause
@@ -88,12 +91,14 @@ type OrderDirection
 
 type alias Model =
     { game : Maybe GameModel
+    , savedGame : Maybe GameModel
     , playedGameHistory : List FinishedGameHistoryEntry
     , currentView : View
     , device : Device
     , key : Key
     , containsGithubPrefixInPath : Bool
     , theme : Theme
+    , runningGameSalt : String
     }
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,8 @@ import * as serviceWorker from './serviceWorker';
 
 const localStoreFinishedGameHistoryKey = 'finishedGameHistory';
 const localStoreThemeKey = 'themePreference';
+const localStoreRunningGameKey = 'runningGame';
+const localStoreRunningGameSaltKey = 'runningGameSalt';
 
 const storedFinishedGameHistory = localStorage.getItem(localStoreFinishedGameHistoryKey);
 const finishedGameHistory = storedFinishedGameHistory ? JSON.parse(storedFinishedGameHistory) : "[]";
@@ -30,6 +32,34 @@ if (!themePref) {
   themePref = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
 
+// Random per-browser salt for the running game checksum. Generated once on
+// first start; without it a stored running game cannot be validated, so a
+// missing or unwritable salt simply invalidates any existing save.
+function generateRunningGameSalt() {
+  const words = new Uint32Array(4);
+  if (window.crypto && window.crypto.getRandomValues) {
+    window.crypto.getRandomValues(words);
+  } else {
+    for (let i = 0; i < words.length; i++) {
+      words[i] = Math.floor(Math.random() * 4294967296);
+    }
+  }
+  return Array.from(words).map((word) => word.toString(16).padStart(8, '0')).join('');
+}
+
+let runningGame = "";
+let runningGameSalt = "";
+try {
+  runningGame = localStorage.getItem(localStoreRunningGameKey) || "";
+  runningGameSalt = localStorage.getItem(localStoreRunningGameSaltKey) || "";
+  if (!runningGameSalt) {
+    runningGameSalt = generateRunningGameSalt();
+    localStorage.setItem(localStoreRunningGameSaltKey, runningGameSalt);
+  }
+} catch (e) {
+  console.warn("Could not read the running game from local storage", e);
+}
+
 const app = Elm.Main.init({
   node: document.getElementById('root'),
   flags: {
@@ -37,7 +67,9 @@ const app = Elm.Main.init({
     height: window.innerHeight,
     width: window.innerWidth,
     initPath : pathname,
-    theme: themePref
+    theme: themePref,
+    runningGame: runningGame,
+    runningGameSalt: runningGameSalt
   }
 });
 
@@ -50,6 +82,22 @@ app.ports.storeFinishedGameHistory.subscribe(function(finishedGameHistory) {
     } catch (e) {
       console.warn("Could not save game history to local storage", e);
     }
+  }
+});
+
+app.ports.storeRunningGame.subscribe(function(runningGameAsJson) {
+  try {
+    localStorage.setItem(localStoreRunningGameKey, runningGameAsJson);
+  } catch (e) {
+    console.warn("Could not save the running game to local storage", e);
+  }
+});
+
+app.ports.clearRunningGame.subscribe(function() {
+  try {
+    localStorage.removeItem(localStoreRunningGameKey);
+  } catch (e) {
+    console.warn("Could not clear the running game in local storage", e);
   }
 });
 

--- a/tests/RunningGamePersistenceTests.elm
+++ b/tests/RunningGamePersistenceTests.elm
@@ -122,6 +122,17 @@ tamperTests =
                     Just encoded ->
                         Game.decodeStoredRunningGame "another-salt" encoded
                             |> Expect.equal Nothing
+        , test "a time segment ending before it starts is rejected despite a valid checksum" <|
+            \_ ->
+                case runningGameModel of
+                    Nothing ->
+                        Expect.fail "Testdata seems to be invalid"
+
+                    Just gameModel ->
+                        { gameModel | gameRunningTimes = [ ( Time.millisToPosix 5000, Time.millisToPosix 1000 ) ] }
+                            |> GameInternal.encodeRunningGame testSalt
+                            |> Maybe.andThen (Game.decodeStoredRunningGame testSalt)
+                            |> Expect.equal Nothing
         , test "a wrong checksum is rejected" <|
             \_ ->
                 envelopeWith 1 0

--- a/tests/RunningGamePersistenceTests.elm
+++ b/tests/RunningGamePersistenceTests.elm
@@ -1,0 +1,237 @@
+{-
+   This file is part of Elm Minesweeper.
+
+   Elm Minesweeper is free software: you can redistribute it and/or modify it under
+   the terms of the GNU Affero General Public License as published by the Free Software
+   Foundation, either version 3 of the License, or (at your option) any later version.
+
+   Elm Minesweeper is distributed in the hope that it will be useful, but WITHOUT ANY
+   WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+   PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License along with
+   Elm Minesweeper. If not, see <https://www.gnu.org/licenses/>.
+
+-}
+
+
+module RunningGamePersistenceTests exposing (..)
+
+import Expect
+import Fuzz
+import Game.Game as Game
+import Game.Internal as GameInternal
+import Grid
+import Json.Encode as Encode
+import Test exposing (..)
+import Time
+import Types exposing (..)
+
+
+testSalt : String
+testSalt =
+    "0123456789abcdef"
+
+
+runningGameModel : Maybe GameModel
+runningGameModel =
+    Grid.fromList
+        [ [ GameCell (MineNeighbourCell 1) Opened, GameCell (MineNeighbourCell 1) Flagged ]
+        , [ GameCell (MineNeighbourCell 1) Untouched, GameCell MineCell Untouched ]
+        ]
+        |> Maybe.map
+            (\grid ->
+                { gameBoardStatus = RunningGame grid
+                , gameInteractionMode = Flag
+                , gameRunningTimes = [ ( Time.millisToPosix 1000, Time.millisToPosix 5000 ) ]
+                , gamePauseResumeState = Resumed 1
+                , lastClockTick = Time.millisToPosix 5000
+                }
+            )
+
+
+checksumTests : Test
+checksumTests =
+    describe "djb2 checksum"
+        [ test "empty string hashes to the djb2 seed" <|
+            \_ ->
+                GameInternal.djb2Hash "" |> Expect.equal 5381
+        , test "known answer for a single character" <|
+            \_ ->
+                -- (5381 * 33) xor 97 = 177604
+                GameInternal.djb2Hash "a" |> Expect.equal 177604
+        , fuzz Fuzz.string "hash is always within the unsigned 32 bit range" <|
+            \randomString ->
+                GameInternal.djb2Hash randomString
+                    |> Expect.all
+                        [ Expect.atLeast 0
+                        , Expect.lessThan 4294967296
+                        ]
+        , fuzz Fuzz.string "checksum combines the static and the browser salt with the payload" <|
+            \randomString ->
+                GameInternal.runningGameChecksum testSalt randomString
+                    |> Expect.equal (GameInternal.djb2Hash (GameInternal.staticChecksumSalt ++ testSalt ++ randomString))
+        ]
+
+
+roundTripTests : Test
+roundTripTests =
+    describe "Encode and decode a running game"
+        [ test "a running game round-trips and is restored as paused" <|
+            \_ ->
+                case runningGameModel of
+                    Nothing ->
+                        Expect.fail "Testdata seems to be invalid"
+
+                    Just gameModel ->
+                        GameInternal.encodeRunningGame testSalt gameModel
+                            |> Maybe.andThen (Game.decodeStoredRunningGame testSalt)
+                            |> Expect.equal (Just { gameModel | gamePauseResumeState = Paused })
+        ]
+
+
+tamperTests : Test
+tamperTests =
+    describe "Tampered or invalid stored games are rejected"
+        [ test "a flipped cell status invalidates the checksum" <|
+            \_ ->
+                case runningGameModel |> Maybe.andThen (GameInternal.encodeRunningGame testSalt) of
+                    Nothing ->
+                        Expect.fail "Testdata seems to be invalid"
+
+                    Just encoded ->
+                        String.replace "\"cellStatus\":\"untouched\"" "\"cellStatus\":\"opened\"" encoded
+                            |> Game.decodeStoredRunningGame testSalt
+                            |> Expect.equal Nothing
+        , test "a manipulated time segment invalidates the checksum" <|
+            \_ ->
+                case runningGameModel |> Maybe.andThen (GameInternal.encodeRunningGame testSalt) of
+                    Nothing ->
+                        Expect.fail "Testdata seems to be invalid"
+
+                    Just encoded ->
+                        String.replace "\"start\":1000" "\"start\":4000" encoded
+                            |> Game.decodeStoredRunningGame testSalt
+                            |> Expect.equal Nothing
+        , test "a save is rejected under a different browser salt" <|
+            \_ ->
+                case runningGameModel |> Maybe.andThen (GameInternal.encodeRunningGame testSalt) of
+                    Nothing ->
+                        Expect.fail "Testdata seems to be invalid"
+
+                    Just encoded ->
+                        Game.decodeStoredRunningGame "another-salt" encoded
+                            |> Expect.equal Nothing
+        , test "a wrong checksum is rejected" <|
+            \_ ->
+                envelopeWith 1 0
+                    |> Maybe.map (Game.decodeStoredRunningGame testSalt)
+                    |> Expect.equal (Just Nothing)
+        , test "an unknown version is rejected even with a valid checksum" <|
+            \_ ->
+                case runningGameModel of
+                    Nothing ->
+                        Expect.fail "Testdata seems to be invalid"
+
+                    Just gameModel ->
+                        case gameModel.gameBoardStatus of
+                            RunningGame grid ->
+                                envelopeWith 2 (GameInternal.runningGameChecksum testSalt (Encode.encode 0 (GameInternal.runningGameValue grid gameModel)))
+                                    |> Maybe.map (Game.decodeStoredRunningGame testSalt)
+                                    |> Expect.equal (Just Nothing)
+
+                            _ ->
+                                Expect.fail "Testdata seems to be invalid"
+        , test "garbage input is rejected" <|
+            \_ ->
+                Game.decodeStoredRunningGame testSalt "asdf" |> Expect.equal Nothing
+        , test "an empty string is rejected" <|
+            \_ ->
+                Game.decodeStoredRunningGame testSalt "" |> Expect.equal Nothing
+        ]
+
+
+{-| Builds the storage envelope around the shared test game with an arbitrary
+version and checksum, bypassing encodeRunningGame's canonical checksum.
+-}
+envelopeWith : Int -> Int -> Maybe String
+envelopeWith version checksum =
+    runningGameModel
+        |> Maybe.andThen
+            (\gameModel ->
+                case gameModel.gameBoardStatus of
+                    RunningGame grid ->
+                        Encode.object
+                            [ ( "version", Encode.int version )
+                            , ( "checksum", Encode.int checksum )
+                            , ( "game", GameInternal.runningGameValue grid gameModel )
+                            ]
+                            |> Encode.encode 0
+                            |> Just
+
+                    _ ->
+                        Nothing
+            )
+
+
+resumeInvariantTests : Test
+resumeInvariantTests =
+    describe "Resuming a game keeps the pause/segment invariant"
+        [ test "resuming a paused game sets the resume counter one ahead of the recorded segments" <|
+            \_ ->
+                case runningGameModel of
+                    Nothing ->
+                        Expect.fail "Testdata seems to be invalid"
+
+                    Just gameModel ->
+                        { gameModel
+                            | gamePauseResumeState = Paused
+                            , gameRunningTimes =
+                                [ ( Time.millisToPosix 1000, Time.millisToPosix 5000 )
+                                , ( Time.millisToPosix 7000, Time.millisToPosix 9000 )
+                                ]
+                        }
+                            |> Game.resumeGame
+                            |> .gamePauseResumeState
+                            |> Expect.equal (Resumed 3)
+        , test "resuming an already running game changes nothing" <|
+            \_ ->
+                case runningGameModel of
+                    Nothing ->
+                        Expect.fail "Testdata seems to be invalid"
+
+                    Just gameModel ->
+                        Game.resumeGame gameModel
+                            |> Expect.equal gameModel
+        ]
+
+
+snapshotScopeTests : Test
+snapshotScopeTests =
+    describe "Only running games are persisted"
+        [ test "a game waiting on the first click is not encoded" <|
+            \_ ->
+                { gameBoardStatus = WaitOnStart { grid = Grid.repeat 4 4 InitGameCell, mines = 3 }
+                , gameInteractionMode = Reveal
+                , gameRunningTimes = []
+                , gamePauseResumeState = Paused
+                , lastClockTick = Time.millisToPosix 0
+                }
+                    |> GameInternal.encodeRunningGame testSalt
+                    |> Expect.equal Nothing
+        , test "a finished game is not encoded" <|
+            \_ ->
+                case runningGameModel of
+                    Nothing ->
+                        Expect.fail "Testdata seems to be invalid"
+
+                    Just gameModel ->
+                        case gameModel.gameBoardStatus of
+                            RunningGame grid ->
+                                { gameModel | gameBoardStatus = FinishedGame grid Lost 4000 }
+                                    |> GameInternal.encodeRunningGame testSalt
+                                    |> Expect.equal Nothing
+
+                            _ ->
+                                Expect.fail "Testdata seems to be invalid"
+        ]


### PR DESCRIPTION
A running game is now stored in localStorage on every clock tick (plus
game start, cell interactions and pause transitions) as a versioned JSON
envelope guarded by a salted djb2 checksum over the board and the elapsed
time segments. The salt combines a static application salt with a random
per-browser salt generated on first start, so casual manual edits of the
stored JSON invalidate the save while - by design without a server - no
cryptographic integrity is claimed.

On startup the save is decoded and validated; the selection view then
offers a full-width "Resume game" tile above the difficulty tiles
(mobile first). Until resumed the restored game counts as paused and its
play time is preserved; resuming opens a fresh time segment in line with
the pause/segment invariant of updateTimePlayGame. The save is removed
when the game finishes, is given up, a new game is created, or the
stored value turns out to be invalid.

calculateElapsedTimeMillis and playGameGridToPlaygroundDefinition moved
from Game.Game to Game.Internal so the selection view can reuse them.
Finished-game history is now only written when a game actually finishes
instead of on every cell click.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018yXMRsX3XVgAdHCxRQ4PzM